### PR TITLE
mediatek: filogic: Enhance compatibility with the CLX S20P

### DIFF
--- a/target/linux/mediatek/dts-ext/mt7986a-clx-s20p.dts
+++ b/target/linux/mediatek/dts-ext/mt7986a-clx-s20p.dts
@@ -13,7 +13,7 @@
 
 	aliases {
 		serial0 = &uart0;
-		label-mac-device = &gmac1;
+		label-mac-device = &gmac0;
 		led-boot = &sys_led;
 		led-failsafe = &sys_led;
 		led-running = &sys_led;
@@ -183,7 +183,7 @@
 
 				port@4 {
 					reg = <4>;
-				    label = "lan1";
+					label = "lan1";
 				};
 
 				port@5 {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -6,6 +6,11 @@ board=$(board_name)
 board_config_update
 
 case $board in
+clx,s20p)
+	ucidef_set_led_netdev "wlan5g" "5G" "blue:wlan-5ghz" "rax0"
+	ucidef_set_led_netdev "wlan2g" "2.4G" "blue:wlan-2ghz" "ra0"
+	ucidef_set_led_timer "sys" "SYS" "blue:status" "1000" "2000"
+	;;
 airpi,ap3000m)
 	ucidef_set_led_netdev "wlan2g" "WLAN2G" "orange:wlan-2ghz" "phy0-ap0" "link tx rx"
 	ucidef_set_led_netdev "wlan5g" "WLAN5G" "white:wlan-5ghz" "phy1-ap0" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -140,6 +140,11 @@ case "$board" in
 		# addresses on multiple VIFs with the other radio. Use label mac to set LA bit.
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(get_mac_label) > /sys${DEVPATH}/macaddress
 		;;
+	clx,s20p)
+		addr=$(mmc_get_mac_binary factory 0x4)
+		[ "$PHYNBR" = "0" ] && $addr > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $addr > /sys${DEVPATH}/macaddress
+		;;
 	jdcloud,re-cp-03)
 		[ "$PHYNBR" = "1" ] && mmc_get_mac_binary factory 0xa > /sys${DEVPATH}/macaddress
 		;;


### PR DESCRIPTION
## Description

Add board support for CLX S20P (MT7986A).

Includes:

- Set gmac0 as label-mac-device
- LED configuration
- WiFi MAC fixup from eMMC factory partition

Tested and working on hardware.

Signed-off-by: hululu1068 <xjianglin@gmail.com>