### PR TITLE
mediatek: filogic: add support for ZHAO 7981r128

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -91,7 +91,8 @@ livinet,zr-3020|\
 netgear,wax220|\
 ruijie,rg-x30e-pro|\
 zbtlink,zbt-z8102ax|\
-zbtlink,zbt-z8103ax)
+zbtlink,zbt-z8103ax|\
+zhao,7981r128)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
 asus,rt-ax59u)

--- a/package/mtk/applications/mtk-smp/files/smp.sh
+++ b/package/mtk/applications/mtk-smp/files/smp.sh
@@ -831,6 +831,7 @@ setup_model()
 	xiaomi,mi-router-wr30u* |\
 	yuncore,ax835 |\
 	zbtlink,zbt-z810* |\
+	zhao,7981r128 |\
 	zyxel,nwa50ax-pro |\
 	*7981*)
 		MT7981_whnat $num_of_wifi $usbnet

--- a/target/linux/mediatek/dts-ext/mt7981b-zhao-7981r128-mtkuboot.dts
+++ b/target/linux/mediatek/dts-ext/mt7981b-zhao-7981r128-mtkuboot.dts
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "ZHAO 7981 R128 (MTK U-Boot layout)";
+	compatible = "mediatek,zhao-7981r128", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sfp: sfp {
+			label = "SFP";
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_wifi5g: wifi5g {
+			label = "WIFI5G";
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led_wifi2g: wifi2g {
+			label = "WIFI2G";
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_lan: lan {
+			label = "LAN";
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_power: power {
+			label = "POWER";
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+
+	i2c_sfp1: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&pio 9 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&pio 10 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-wan {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_sfp1>;
+		los-gpios = <&pio 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpios = <&pio 34 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <3000>;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+		regulator-boot-on;
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 0>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		managed = "in-band-status";
+		sfp = <&sfp1>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 1>;
+	};
+};
+
+&mdio_bus {
+	phy5: phy@5 {
+		compatible = "ethernet-phy-id67c9.de0a";
+		reg = <5>;
+		reset-gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <600>;
+		reset-deassert-us = <20000>;
+		phy-mode = "2500base-x";
+	};
+
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <0x1f>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@1 {
+			reg = <1>;
+			label = "lan1";
+		};
+
+		port@5 {
+			reg = <5>;
+			label = "lan2";
+			phy-mode = "2500base-x";
+			phy-handle = <&phy5>;
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x7200000>;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>;
+};
+
+&xhci {
+	mediatek,u3p-dis-msk = <0x0>;
+	status = "okay";
+};

--- a/target/linux/mediatek/dts-ext/mt7981b-zhao-7981r128-mtkuboot.dts
+++ b/target/linux/mediatek/dts-ext/mt7981b-zhao-7981r128-mtkuboot.dts
@@ -8,8 +8,8 @@
 #include "mt7981b.dtsi"
 
 / {
-	model = "ZHAO 7981 R128 (MTK U-Boot layout)";
-	compatible = "mediatek,zhao-7981r128", "mediatek,mt7981";
+	model = "ZHAO 7981r128 (MTK U-Boot layout)";
+	compatible = "zhao,7981r128", "mediatek,mt7981";
 
 	aliases {
 		label-mac-device = &gmac0;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -226,12 +226,6 @@ openwrt,one)
 	ucidef_set_led_netdev "lanact" "LANACT" "green:lan" "eth1" "rx tx"
 	ucidef_set_led_netdev "lanlink" "LANLINK" "amber:lan" "eth1" "link"
 	;;
-mediatek,zhao-7981r128)
-	ucidef_set_led_netdev "lan" "LAN" "LAN" "lan2"
-	ucidef_set_led_netdev "sfp" "SFP" "SFP" "eth1"
-	ucidef_set_led_netdev "wlan2g" "WIFI2G" "WIFI2G" "phy0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WIFI5G" "WIFI5G" "phy1-ap0"
-	;;
 routerich,ax3000|\
 routerich,ax3000-ubootmod)
 	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-1" "lan1" "link tx rx"
@@ -375,6 +369,12 @@ zbtlink,zbt-z8106ax-s|\
 zbtlink,zbt-z8106ax-t)
 	ucidef_set_led_netdev "wan" "wan" "amber:wan" "eth1" "link tx rx"
 	ucidef_set_led_netdev "mobile" "mobile" "green:mobile" "wwan" "link tx rx"
+	;;
+zhao,7981r128)
+	ucidef_set_led_netdev "lan" "LAN" "LAN" "lan2"
+	ucidef_set_led_netdev "sfp" "SFP" "SFP" "eth1"
+	ucidef_set_led_netdev "wlan2g" "WIFI2G" "WIFI2G" "ra0"
+	ucidef_set_led_netdev "wlan5g" "WIFI5G" "WIFI5G" "rax0"
 	;;
 zyxel,ex5601-t0-stock|\
 zyxel,ex5601-t0-ubootmod)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -226,6 +226,12 @@ openwrt,one)
 	ucidef_set_led_netdev "lanact" "LANACT" "green:lan" "eth1" "rx tx"
 	ucidef_set_led_netdev "lanlink" "LANLINK" "amber:lan" "eth1" "link"
 	;;
+mediatek,zhao-7981r128)
+	ucidef_set_led_netdev "lan" "LAN" "LAN" "lan2"
+	ucidef_set_led_netdev "sfp" "SFP" "SFP" "eth1"
+	ucidef_set_led_netdev "wlan2g" "WIFI2G" "WIFI2G" "phy0-ap0"
+	ucidef_set_led_netdev "wlan5g" "WIFI5G" "WIFI5G" "phy1-ap0"
+	;;
 routerich,ax3000|\
 routerich,ax3000-ubootmod)
 	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-1" "lan1" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -147,9 +147,6 @@ mediatek_setup_interfaces()
 	wirelesstag,zx7981pd-ubootmod)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" wan
 		;;
-	mediatek,zhao-7981r128)
-		ucidef_set_interfaces_lan_wan "lan1 lan2" eth1
-		;;
 	airpi,ap3000m|\
 	bananapi,bpi-r3-mini|\
 	edgecore,eap111|\
@@ -219,7 +216,8 @@ mediatek_setup_interfaces()
 	tplink,tl-xdr6086|\
 	wavlink,wl-wn551x3|\
 	wavlink,wl-wn586x3|\
-	wavlink,wl-wn586x3b)
+	wavlink,wl-wn586x3b|\
+	zhao,7981r128)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" eth1
 		;;
 	tplink,archer-ax80-v1|\
@@ -310,11 +308,6 @@ mediatek_setup_macs()
 		lan_mac=$(mtd_get_mac_binary "Factory" "0xFFFF4")
 		wan_mac=$(mtd_get_mac_binary "Factory" "0xFFFFA")
 		;;
-	mediatek,zhao-7981r128)
-		lan_mac=$(mtd_get_mac_binary "Factory" 0x04)
-		wan_mac=$(macaddr_add "$lan_mac" 1)
-		label_mac=$lan_mac
-		;;
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
 	tplink,archer-ax80-v1-eu|\
@@ -369,6 +362,11 @@ mediatek_setup_macs()
 		;;
 	yuncore,ax835)
 		label_mac=$(mtd_get_mac_binary "Factory" 0x4)
+		;;
+	zhao,7981r128)
+		lan_mac=$(mtd_get_mac_binary "Factory" 0x04)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+		label_mac=$lan_mac
 		;;
 	esac
 

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -147,6 +147,9 @@ mediatek_setup_interfaces()
 	wirelesstag,zx7981pd-ubootmod)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" wan
 		;;
+	mediatek,zhao-7981r128)
+		ucidef_set_interfaces_lan_wan "lan1 lan2" eth1
+		;;
 	airpi,ap3000m|\
 	bananapi,bpi-r3-mini|\
 	edgecore,eap111|\
@@ -306,6 +309,11 @@ mediatek_setup_macs()
 	mediatek,mt7988*)
 		lan_mac=$(mtd_get_mac_binary "Factory" "0xFFFF4")
 		wan_mac=$(mtd_get_mac_binary "Factory" "0xFFFFA")
+		;;
+	mediatek,zhao-7981r128)
+		lan_mac=$(mtd_get_mac_binary "Factory" 0x04)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+		label_mac=$lan_mac
 		;;
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -203,6 +203,7 @@ platform_do_upgrade() {
 	huasifei,wh3000-pro-nand|\
 	huasifei,wh3000r-nand|\
 	jiorouter,ax6000-jidu6101|\
+	mediatek,zhao-7981r128|\
 	ruijie,rg-x30e-pro)
 		CI_UBIPART="ubi"
 		nand_do_upgrade "$1"
@@ -377,6 +378,7 @@ platform_check_image() {
 		;;
 	creatlentem,clt-r30b1|\
 	creatlentem,clt-r30b1-112m|\
+	mediatek,zhao-7981r128|\
 	nradio,c8-668gl)
 		# tar magic `ustar`
 		magic="$(dd if="$1" bs=1 skip=257 count=5 2>/dev/null)"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -203,8 +203,8 @@ platform_do_upgrade() {
 	huasifei,wh3000-pro-nand|\
 	huasifei,wh3000r-nand|\
 	jiorouter,ax6000-jidu6101|\
-	mediatek,zhao-7981r128|\
-	ruijie,rg-x30e-pro)
+	ruijie,rg-x30e-pro|\
+	zhao,7981r128)
 		CI_UBIPART="ubi"
 		nand_do_upgrade "$1"
 		;;
@@ -378,8 +378,8 @@ platform_check_image() {
 		;;
 	creatlentem,clt-r30b1|\
 	creatlentem,clt-r30b1-112m|\
-	mediatek,zhao-7981r128|\
-	nradio,c8-668gl)
+	nradio,c8-668gl|\
+	zhao,7981r128)
 		# tar magic `ustar`
 		magic="$(dd if="$1" bs=1 skip=257 count=5 2>/dev/null)"
 

--- a/target/linux/mediatek/image/filogic-ext.mk
+++ b/target/linux/mediatek/image/filogic-ext.mk
@@ -179,25 +179,6 @@ endif
 endef
 TARGET_DEVICES += wirelesstag_zx7981pd-ubootmod
 
-define Device/zhao_7981-r128-mtkuboot
-  DEVICE_VENDOR := ZHAO
-  DEVICE_MODEL := 7981 R128
-  DEVICE_VARIANT := (MTK U-Boot layout)
-  DEVICE_DTS := mt7981b-zhao-7981r128-mtkuboot
-  DEVICE_DTS_DIR := ../dts-ext
-  SUPPORTED_DEVICES := mediatek,zhao-7981r128
-  DEVICE_PACKAGES := kmod-usb3 kmod-sfp kmod-i2c-gpio automount f2fsck mkf2fs
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 114688k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += zhao_7981-r128-mtkuboot
-
 define Device/xiaomi_mi-router-ax3000t-mtkuboot
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router AX3000T
@@ -248,3 +229,22 @@ define Device/xiaomi_redmi-router-ax6000-mtkuboot
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += xiaomi_redmi-router-ax6000-mtkuboot
+
+define Device/zhao_7981r128-mtkuboot
+  DEVICE_VENDOR := ZHAO
+  DEVICE_MODEL := 7981r128
+  DEVICE_VARIANT := (MTK U-Boot layout)
+  DEVICE_DTS := mt7981b-zhao-7981r128-mtkuboot
+  DEVICE_DTS_DIR := ../dts-ext
+  SUPPORTED_DEVICES := zhao,7981r128
+  DEVICE_PACKAGES := kmod-usb3 kmod-sfp kmod-i2c-gpio automount f2fsck mkf2fs
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 114688k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += zhao_7981r128-mtkuboot

--- a/target/linux/mediatek/image/filogic-ext.mk
+++ b/target/linux/mediatek/image/filogic-ext.mk
@@ -179,6 +179,25 @@ endif
 endef
 TARGET_DEVICES += wirelesstag_zx7981pd-ubootmod
 
+define Device/zhao_7981-r128-mtkuboot
+  DEVICE_VENDOR := ZHAO
+  DEVICE_MODEL := 7981 R128
+  DEVICE_VARIANT := (MTK U-Boot layout)
+  DEVICE_DTS := mt7981b-zhao-7981r128-mtkuboot
+  DEVICE_DTS_DIR := ../dts-ext
+  SUPPORTED_DEVICES := mediatek,zhao-7981r128
+  DEVICE_PACKAGES := kmod-usb3 kmod-sfp kmod-i2c-gpio automount f2fsck mkf2fs
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 114688k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += zhao_7981-r128-mtkuboot
+
 define Device/xiaomi_mi-router-ax3000t-mtkuboot
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router AX3000T


### PR DESCRIPTION
Hardware specification:
SoC: MediaTek MT7981B 2x A53
Flash: 128 MB SPI-NAND
RAM: 512MB
Ethernet: 1x 10/100/1000 Mbps, 1x 10/100/1000/2500 Mbps and 1x SFP
Switch: MediaTek MT7531AE
WiFi: MediaTek MT7976C
Button: Reset, Mesh
Power: DC 12V 2A

Device from: https://www.right.com.cn/forum/thread-8386410-1-1.html