### PR TITLE
mtk: mt_wifi: don't reject assoc on oversized Supported Channels IE

### DIFF
--- a/package/mtk/drivers/mt_wifi/patches-7673/040-ap_mgmt_assoc-dont-reject-oversized-supported-channels-ie.patch
+++ b/package/mtk/drivers/mt_wifi/patches-7673/040-ap_mgmt_assoc-dont-reject-oversized-supported-channels-ie.patch
@@ -1,0 +1,21 @@
+mtk: mt_wifi: don't reject assoc on oversized Supported Channels IE
+
+7.6.7.3 made PeerAssocReqCmmSanity() reject the whole assoc when the
+Supported Channels IE (EID 36) is longer than MAX_LEN_OF_SUPPORTED_CHL (64).
+Some clients (e.g. Intel AX210) send a 74-byte IE, so 5 GHz assoc always
+fails (#20, #56). Reject only odd-length IEs and clamp oversized ones, like
+7.6.7.2 did; the copy is already bounded, so it stays safe.
+
+Signed-off-by: SuperKali <hello@superkali.me>
+
+--- a/mt_wifi/embedded/fsm/ap_mgmt_assoc.c
++++ b/mt_wifi/embedded/fsm/ap_mgmt_assoc.c
+@@ -1434,7 +1434,7 @@
+ #endif /* DOT11_VHT_AC */
+ 
+ 		case IE_SUPP_CHANNELS:
+-			if (eid_ptr->Len > MAX_LEN_OF_SUPPORTED_CHL || (eid_ptr->Len % 2)) {
++			if (eid_ptr->Len % 2) {
+ 				MTWF_DBG(pAd, DBG_CAT_AP, DBG_SUBCAT_ALL, DBG_LVL_INFO, "wrong IE_SUPP_CHANNELS, eid->Len = %d\n",
+ 						 eid_ptr->Len);
+ 				return FALSE;


### PR DESCRIPTION
Fixes the Intel AX210 5 GHz association failure reported in #20 and #56.

## Root cause
Driver 7.6.7.3 tightened `PeerAssocReqCmmSanity()` (`mt_wifi/embedded/fsm/ap_mgmt_assoc.c`, case `IE_SUPP_CHANNELS`) to `return FALSE` when the Supported Channels IE (EID 36) is longer than `MAX_LEN_OF_SUPPORTED_CHL` (64). The AX210 advertises a 74-byte Supported Channels IE (2.4 + 5 + 6 GHz subbands), so every 5 GHz association is refused:

```
PeerAssocReqCmmSanity() wrong IE_SUPP_CHANNELS, eid->Len = 74
MacTableMaintenance() <mac> fail to complete ASSOC in 5 sec
```

7.6.7.2 only rejected odd-length IEs and clamped oversized ones to 64 via the existing else-if branches. The copy is already bounded to `MAX_LEN_OF_SUPPORTED_CHL`, so it stays buffer-safe.

## Fix
Reject only malformed odd-length IEs; let oversized ones fall through to the clamping path (restores 7.6.7.2 behaviour).

## Testing
ZX7981PD (MT7981), driver 7673 + fw20260601:

- before: `SETKEYS(rax0)=0`, AX210 never associates on 5 GHz, assoc-fail loop
- after: `AP SETKEYS DONE(rax0)` WPA3PSK, 5 GHz HE160 stable, ping 0% loss

Not SAE-specific: also reproduced with WPA2 on 5 GHz. 2.4 GHz was unaffected (it sends a shorter IE).
