### PR TITLE
mtk: mt_hwifi: add built-in firmware header kconfig

### DIFF
--- a/package/mtk/drivers/mt_hwifi/Makefile
+++ b/package/mtk/drivers/mt_hwifi/Makefile
@@ -349,6 +349,10 @@ ifeq ($(CONFIG_MTK_HWIFI_MEM_SHRINK),y)
 	MTK_HWIFI_C_FLAGS+=CONFIG_HWIFI_MEM_SHRINK=y
 endif
 
+ifeq ($(CONFIG_MTK_HWIFI_FW_HDR_SUPPORT),y)
+	MTK_HWIFI_C_FLAGS+=CONFIG_HWIFI_FW_HDR_SUPPORT=y
+endif
+
 ifeq ($(CONFIG_PACKAGE_kmod-mt_wifi_cmn),y)
 KCFLAGS += \
 	-DMT_WIFI_COMMON_SUPPORT
@@ -607,6 +611,7 @@ endef
 
 define Build/Compile/mt7992
 #Copy Kite FW header for differnet SKUs
+ifeq ($(CONFIG_MTK_HWIFI_FW_HDR_SUPPORT),y)
 ifeq ($(CONFIG_MTK_WIFI7_CHIP_MT7992),y)
 	[ -x $(PKG_BUILD_DIR)/mt_wifi/tools/bin2h ] || $(MAKE) -C $(PKG_BUILD_DIR)/mt_wifi/tools
 	TOP_DIR="$(PKG_BUILD_DIR)/mt_wifi" \
@@ -709,10 +714,12 @@ endif
 		$(PKG_BUILD_DIR)/mt_wifi/include/hw_ctrl/mcu_hdr/WIFI_MT7992_WACPU_RAM_CODE_1_1_sdb.h > $(PKG_BUILD_DIR)/mt_wifi/include/hw_ctrl/mcu_hdr/WIFI_MT7992_WACPU_RAM_CODE_1_1.h
 endif
 endif
+endif
 endef
 
 define Build/Compile/mt7990
 #Copy Eagle FW header for differnet SKUs
+ifeq ($(CONFIG_MTK_HWIFI_FW_HDR_SUPPORT),y)
 ifeq ($(CONFIG_MTK_HWIFI_MT7990),y)
 ifeq ($(CONFIG_MTK_WIFI7_2ADIE_TRIBAND),y)
 	cp -rf $(PKG_BUILD_DIR)/mt_wifi/include/hw_ctrl/mcu_hdr/WIFI_MT7990_PATCH_MCU_1_1_hdr_2adie.h $(PKG_BUILD_DIR)/mt_wifi/include/hw_ctrl/mcu_hdr/WIFI_MT7990_PATCH_MCU_1_1_hdr.h
@@ -724,6 +731,7 @@ else
 	cp -rf $(PKG_BUILD_DIR)/mt_wifi/include/hw_ctrl/mcu_hdr/WIFI_MT7990_WACPU_RAM_CODE_1_1_.h $(PKG_BUILD_DIR)/mt_wifi/include/hw_ctrl/mcu_hdr/WIFI_MT7990_WACPU_RAM_CODE_1_1.h
 	cp -rf $(PKG_BUILD_DIR)/mt_wifi/include/hw_ctrl/mcu_hdr/WIFI_RAM_CODE_MT7990_1_1_.h $(PKG_BUILD_DIR)/mt_wifi/include/hw_ctrl/mcu_hdr/WIFI_RAM_CODE_MT7990_1_1.h
 	cp -rf $(PKG_BUILD_DIR)/mt_wifi/include/hw_ctrl/mcu_hdr/WIFI_RAM_CODE_MT7990_1_1_TESTMODE_.h $(PKG_BUILD_DIR)/mt_wifi/include/hw_ctrl/mcu_hdr/WIFI_RAM_CODE_MT7990_1_1_TESTMODE.h
+endif
 endif
 endif
 endef

--- a/package/mtk/drivers/mt_hwifi/config.in
+++ b/package/mtk/drivers/mt_hwifi/config.in
@@ -49,6 +49,11 @@ config MTK_HWIFI_TDMA_SW_ACK_SUPPORT
     depends on PACKAGE_kmod-mt_hwifi
     default n
 
+config MTK_HWIFI_FW_HDR_SUPPORT
+	bool "HWIFI built-in firmware header support"
+	depends on PACKAGE_kmod-mt_hwifi
+	default n
+
 menu "HWIFI Chips Support"
 	config MTK_HWIFI_MT7915
 		bool "mt7915"

--- a/package/mtk/drivers/mt_wifi7/patches/014-mt_hwifi-add-fw-hdr-support-flag.patch
+++ b/package/mtk/drivers/mt_wifi7/patches/014-mt_hwifi-add-fw-hdr-support-flag.patch
@@ -1,0 +1,22 @@
+--- a/wlan_hwifi/Makefile
++++ b/wlan_hwifi/Makefile
+@@ -79,7 +79,9 @@ ifeq ($(CONFIG_HWIFI_ARCH_NEW_FWDL), y)
+ 	ccflags-y += -DCONFIG_HWIFI_ARCH_NEW_FWDL
+ endif
+ 
+-ccflags-y += -DCONFIG_HWIFI_FW_HDR_SUPPORT
++ifeq ($(CONFIG_HWIFI_FW_HDR_SUPPORT), y)
++	ccflags-y += -DCONFIG_HWIFI_FW_HDR_SUPPORT
++endif
+ 
+ obj-$(CONFIG_HWIFI) += mtk_hwifi.o
+ mtk_hwifi-y := main.o bus.o mac_if.o chips.o utility.o
+--- a/wlan_hwifi/config.mk
++++ b/wlan_hwifi/config.mk
+@@ -45,3 +45,6 @@ CONFIG_HWIFI_USE_PCIE0_TXRING21=n
+ 
+ #HWIFI SW Path Rx process
+ CONFIG_HWIFI_RX_PROCESS_WORKQUEUE=n
++
++#HWIFI FW header support
++CONFIG_HWIFI_FW_HDR_SUPPORT=n


### PR DESCRIPTION
Original makefile copies firmware headers and build-in these headers to
kmod-mt799x by default as fallback, but we already have binary files at
`/lib/firmware`. This commit helps reduce kmod-mt799x size.

FIxes: #86 