### PR TITLE
iwinfo: fix UCI string use-after-free in mtk backend

### DIFF
--- a/package/network/utils/iwinfo/src/iwinfo_mtk.c
+++ b/package/network/utils/iwinfo/src/iwinfo_mtk.c
@@ -11,23 +11,32 @@ static inline int mtk_ioctl(const char *ifname, int cmd, struct iwreq *wrq)
 	return iwinfo_ioctl(cmd, wrq);
 }
 
-static const char *mtk_dev2phy(const char *devname)
+static int mtk_dev2phy(const char *devname, char *phy, size_t len)
 {
-	const char *phy = NULL;
 	struct uci_section *s;
+	const char *value;
+	int ret = -1;
 
-	if (strstr(devname,"ra") || strstr(devname,"apcli"))
-		return devname;
+	if (!devname || !phy || !len)
+		return -1;
+
+	if (strstr(devname,"ra") || strstr(devname,"apcli")) {
+		snprintf(phy, len, "%s", devname);
+		return 0;
+	}
 
 	s = iwinfo_uci_get_radio(devname, "mtwifi");
-	if (!s)
-		goto out;
-	
-	phy = uci_lookup_option_string(uci_ctx, s, "phy");
+	if (s) {
+		value = uci_lookup_option_string(uci_ctx, s, "phy");
+		if (value && value[0]) {
+			snprintf(phy, len, "%s", value);
+			ret = 0;
+		}
+	}
 
-out:
 	iwinfo_uci_free();
-	return phy;
+
+	return ret;
 }
 
 static int mtk_probe(const char *dev)
@@ -76,12 +85,11 @@ static int mtk_is_ifup(const char *ifname)
 static int mtk_get_band(const char *dev)
 {
 	struct iwreq wrq;
-	const char* ifname;
+	char ifname[IFNAMSIZ];
 	int chband;
 
 	/* get band base on ioctl */
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	if (!mtk_is_ifup(ifname))
@@ -130,10 +138,9 @@ static int mtk_channel2freq(int channel, enum MTK_CH_BAND band)
 static int mtk_get_mode(const char *dev, int *buf)
 {
 	struct iwreq wrq;
-	const char *ifname;
+	char ifname[IFNAMSIZ];
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	if(mtk_ioctl(ifname, SIOCGIWMODE, &wrq) >= 0)
@@ -170,10 +177,9 @@ static int mtk_get_mode(const char *dev, int *buf)
 static int mtk_get_ssid(const char *dev, char *buf)
 {
 	struct iwreq wrq = {};
-	const char *ifname;
+	char ifname[IFNAMSIZ];
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	wrq.u.essid.pointer = buf;
@@ -188,10 +194,9 @@ static int mtk_get_ssid(const char *dev, char *buf)
 static int mtk_get_bssid(const char *dev, char *buf)
 {
 	struct iwreq wrq;
-	const char *ifname;
+	char ifname[IFNAMSIZ];
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	if(mtk_ioctl(ifname, SIOCGIWAP, &wrq) >= 0)
@@ -210,10 +215,9 @@ static int mtk_get_bssid(const char *dev, char *buf)
 static int mtk_get_bitrate(const char *dev, int *buf)
 {
 	struct iwreq wrq;
-	const char *ifname;
+	char ifname[IFNAMSIZ];
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	if(mtk_ioctl(ifname, SIOCGIWRATE, &wrq) >= 0)
@@ -228,10 +232,9 @@ static int mtk_get_bitrate(const char *dev, int *buf)
 static int mtk_get_channel(const char *dev, int *buf)
 {
 	struct iwreq wrq;
-	const char *ifname;
+	char ifname[IFNAMSIZ];
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	if (mtk_ioctl(ifname, SIOCGIWFREQ, &wrq) >= 0)
@@ -276,10 +279,9 @@ static int mtk_get_frequency(const char *dev, int *buf)
 static int mtk_get_txpower(const char *dev, int *buf)
 {
 	struct iwreq wrq;
-	const char *ifname;
+	char ifname[IFNAMSIZ];
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	wrq.u.txpower.flags = 0;
@@ -414,10 +416,9 @@ static int mtk_get_assoclist(const char *dev, char *buf, int *len)
 	struct iwreq wrq = {};
 	RT_802_11_MAC_TABLE *table;
 	int i;
-	const char *ifname;
+	char ifname[IFNAMSIZ];
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	table = calloc(1, sizeof(RT_802_11_MAC_TABLE));
@@ -491,10 +492,9 @@ static int mtk_get_scanlist(const char *dev, char *buf, int *len)
 	int index = 0;
 	int total = -1;
 	char *pos;
-	const char *ifname;
+	char ifname[IFNAMSIZ];
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	*len = 0;
@@ -630,12 +630,11 @@ static int mtk_get_freqlist(const char *dev, char *buf, int *len)
 	struct iwreq wrq;
 	struct channel_list_basic ch_list;
 	struct iwinfo_freqlist_entry entry;
-	const char* ifname;
+	char ifname[IFNAMSIZ];
 	int i, bl;
 	int band;
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	if (!mtk_is_ifup(ifname))
@@ -673,12 +672,11 @@ static int mtk_get_freqlist(const char *dev, char *buf, int *len)
 
 static int mtk_get_country(const char *dev, char *buf)
 {
-	const char *ifname;
+	char ifname[IFNAMSIZ];
 	char data[4] = {0};
 	struct iwreq wrq;
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	wrq.u.data.length = sizeof(data);
@@ -724,9 +722,6 @@ static int mtk_get_hwmodelist(const char *dev, int *buf)
 	
 	band = uci_lookup_option_string(uci_ctx, s, "band");
 
-uciout:
-	iwinfo_uci_free();
-
 	if (band) {
 		if (!strcmp(band,"2g"))
 			*buf = (IWINFO_80211_N | IWINFO_80211_AX);
@@ -734,8 +729,13 @@ uciout:
 			*buf = (IWINFO_80211_AC | IWINFO_80211_AX);
 		else if (!strcmp(band,"6g"))
 			*buf = IWINFO_80211_AX;
+
+		iwinfo_uci_free();
 		return 0;
 	}
+
+uciout:
+	iwinfo_uci_free();
 
 	chband = mtk_get_band(dev);
 	if (chband < 0)
@@ -767,9 +767,6 @@ static int mtk_get_htmodelist(const char *dev, int *buf)
 	
 	band = uci_lookup_option_string(uci_ctx, s, "band");
 
-uciout:
-	iwinfo_uci_free();
-
 	if (band) {
 		if (!strcmp(band,"2g"))
 			*buf = (IWINFO_HTMODE_HT20 | IWINFO_HTMODE_HT40 | IWINFO_HTMODE_HE20 | IWINFO_HTMODE_HE40);
@@ -779,8 +776,12 @@ uciout:
 		else if (!strcmp(band,"6g"))
 			*buf = (IWINFO_HTMODE_HE20 | IWINFO_HTMODE_HE40 | IWINFO_HTMODE_HE80 | IWINFO_HTMODE_HE160);
 
+		iwinfo_uci_free();
 		return 0;
 	}
+
+uciout:
+	iwinfo_uci_free();
 
 	chband = mtk_get_band(dev);
 	if (chband < 0)
@@ -805,13 +806,12 @@ uciout:
 
 static int mtk_get_htmode(const char *dev, int *buf)
 {
-	const char *ifname;
+	char ifname[IFNAMSIZ];
 	struct iwreq wrq;
 	unsigned char bw = 0;
 	unsigned long wmode = 0;
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	if (!mtk_is_ifup(ifname))
@@ -862,14 +862,13 @@ static int mtk_get_htmode(const char *dev, int *buf)
 
 static int mtk_get_encryption(const char *dev, char *buf)
 {
-	const char *ifname;
+	char ifname[IFNAMSIZ];
 	struct iwreq wrq;
 	struct security_info secinfo;
 	unsigned int authMode, encryMode;
 	struct iwinfo_crypto_entry *c = (struct iwinfo_crypto_entry *)buf;
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	if (!mtk_is_ifup(ifname))
@@ -953,10 +952,9 @@ static int mtk_get_encryption(const char *dev, char *buf)
 
 static int mtk_get_phyname(const char *dev, char *buf)
 {
-	const char *ifname;
+	char ifname[IFNAMSIZ];
 
-	ifname = mtk_dev2phy(dev);
-	if (!ifname)
+	if (mtk_dev2phy(dev, ifname, sizeof(ifname)) < 0)
 		return -1;
 
 	strcpy(buf, ifname);


### PR DESCRIPTION
这其实是个蛮明显的BUG，我把wireguard或者tailscale编译进固件的时候，触发了2.4G或者5G的信道偶尔不显示，虽然功能没受影响，但是这个真的急死强迫症，一开始想着等你修，我也懒，忘了提，后来一段时间过去了。。。我自己修好了。。。

mtk_dev2phy() returned a pointer owned by the UCI context after iwinfo_uci_free() had already freed it, so every caller got a dangling phy name. Copy the resolved name into a caller-provided buffer instead.

mtk_get_hwmodelist() and mtk_get_htmodelist() also compared the "band" option string after freeing the UCI context; compare it before the free.

## Problem
On MTK (mtwifi) devices, the LuCI wireless page sometimes fails to show the
2.4G channel dropdown while backend queries still work.

Root cause: mtk_dev2phy() returned a pointer into the UCI context after
iwinfo_uci_free() (which calls uci_free_context()) had already freed it, so
every caller got a dangling phy name. iwinfo MT7986_1_1 info segfaulted, while
ra0 worked because it takes the early strstr(devname, "ra") path and never
touches UCI.

mtk_get_hwmodelist() and mtk_get_htmodelist() had the same pattern: they
compared the UCI "band" option string after freeing the context.

## Fix
- Change mtk_dev2phy() to copy the resolved phy name into a caller-provided
  buffer (char ifname[IFNAMSIZ]) and free the UCI context before returning.
- Update all 14 call sites to the new signature.
- In both modelist helpers, compare "band" before iwinfo_uci_free().

## Test
- iwinfo MT7986_1_1 info no longer segfaults.
- ubus call iwinfo freqlist '{"device":"MT7986_1_1"}' returns 2.4G channels 1-13.
- LuCI wireless page shows the 2.4G channel dropdown again.