### PR TITLE
iwinfo: mtk: fix scan buffer length and SSID bounds

### DIFF
--- a/package/network/utils/iwinfo/src/iwinfo_mtk.c
+++ b/package/network/utils/iwinfo/src/iwinfo_mtk.c
@@ -509,7 +509,7 @@ static int mtk_get_scanlist(const char *dev, char *buf, int *len)
 
 	while (1) {
 		memset(data, 0, data_len);
-		if (mtk_get_scanlist_dump(ifname, index, data, sizeof(data))) {
+		if (mtk_get_scanlist_dump(ifname, index, data, data_len)) {
 			free(data);
 			return -1;
 		}
@@ -606,7 +606,12 @@ static int mtk_get_scanlist(const char *dev, char *buf, int *len)
 				mac + 0, mac + 1, mac + 2, mac + 3, mac + 4, mac + 5);
 
 			sscanf(pos + offsets[SCAN_DATA_SSID_LEN], "%d", &ssid_len);
+			if (ssid_len < 0)
+				ssid_len = 0;
+			if (ssid_len > IWINFO_ESSID_MAX_SIZE)
+				ssid_len = IWINFO_ESSID_MAX_SIZE;
 			memcpy(e->ssid, pos + offsets[SCAN_DATA_SSID], ssid_len);
+			e->ssid[ssid_len] = '\0';
 
 			*len += sizeof(struct iwinfo_scanlist_entry);
 			e++;


### PR DESCRIPTION
## Summary

- pass the allocated scan buffer size to the MTK site-survey ioctl instead of `sizeof(data)`, which is only the pointer size
- clamp the driver-reported SSID length to `IWINFO_ESSID_MAX_SIZE`
- explicitly NUL-terminate copied SSIDs

This prevents out-of-bounds copies and malformed scan result strings. On MT7986, the malformed results were visible as truncated or invalid UTF-8 in Chinese SSIDs.

## Testing

- `make package/network/utils/iwinfo/clean`
- `make package/network/utils/iwinfo/compile -j12 V=s`
- `make -j12`
- full JDCloud RE-CP-03 / MT7986 image built successfully with Linux 6.12.103

The equivalent buffer length and SSID bounds handling are already present in the 6.6 branch, where the same scan results are displayed correctly.